### PR TITLE
Update requests package version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ numpy==1.26.4
 openai==1.25.1
 pdfplumber==0.11.0
 python-dotenv==1.0.1
-Requests==2.31.0
+requests>=2.32.0
 soundfile==0.12.1
 textstat==0.7.3
 transformers==4.38.2


### PR DESCRIPTION
The version of the requests library stated in `requirements.txt` is updated. The change precludes version 2.31.0 and allows all newer versions starting from 2.32.0. Addressing CVE-2024-35195.